### PR TITLE
Update rna-seq-strand.md with HISAT2 settings

### DIFF
--- a/notes/rna-seq-strand.md
+++ b/notes/rna-seq-strand.md
@@ -9,6 +9,7 @@
 | subread featureCounts `-s`           | `1`                                  | `2`                                  |
 | RSEM `--forward-prob`                | `1`                                  | `0`                                  |
 | Salmon/Sailfish `--libType`          | `SF`/`ISF`                           | `SR`/`ISR`                           |
+| HISAT2 `--rna-strandness`            | `FR` (`F` for single-end)            | `RF` (`R` for single-end)            |
 | Library Kit                          | Illumina ScriptSeq                   | Illumina TruSeq Stranded Total RNA   |
 
 ***


### PR DESCRIPTION
I'm a bit dyslexic sometimes so your notes have been helpful to me! I added the settings for HISAT2 to your table.

From HISAT2 manual:
`--rna-strandness <string>` Specify strand-specific information: the default is unstranded.
For single-end reads, use F or R. 'F' means a read corresponds to a transcript. 'R' means a read corresponds to the reverse complemented counterpart of a transcript. For paired-end reads, use either FR or RF.

(TopHat has a similar option, --library-type option, where fr-firststrand corresponds to R and RF; fr-secondstrand corresponds to F and FR.)